### PR TITLE
Update default setting to match actual hardware

### DIFF
--- a/bringup/mini/acorn_litex_soc/README.md
+++ b/bringup/mini/acorn_litex_soc/README.md
@@ -7,7 +7,7 @@
 [> Build
 --------
 ./sqrl_acorn.py --build --load
-litex_term /dev/ttyUSBX (X=1 if only the baseboard connected).
+litex_term /dev/ttyUSBX (X=2 if only the baseboard connected).
 
 [> Check
 --------

--- a/bringup/mini/acorn_litex_soc/sqrl_acorn.py
+++ b/bringup/mini/acorn_litex_soc/sqrl_acorn.py
@@ -9,7 +9,7 @@
 # Build/Use ----------------------------------------------------------------------------------------
 # Build/Load bitstream:
 # ./sqrl_acorn.py --build --load
-# litex_term /dev/ttyUSBX (X=1 if only the baseboard connected).
+# litex_term /dev/ttyUSBX (X=2 if only the baseboard connected).
 
 import os
 

--- a/bringup/mini/acorn_litex_soc/sqrl_acorn_platform.py
+++ b/bringup/mini/acorn_litex_soc/sqrl_acorn_platform.py
@@ -130,7 +130,7 @@ class Platform(Xilinx7SeriesPlatform):
 
     def create_programmer(self, name='openocd'):
         if name == 'openocd':
-            return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a200t.bit")
+            return OpenOCD("openocd_xc7_ft4232.cfg", "bscan_spi_xc7a200t.bit")
         elif name == 'vivado':
             # TODO: some board versions may have s25fl128s
             return VivadoProgrammer(flash_part='s25fl256sxxxxxx0-spi-x1_x2_x4')

--- a/bringup/mini/acorn_pcie/sqrl_acorn_platform.py
+++ b/bringup/mini/acorn_pcie/sqrl_acorn_platform.py
@@ -130,7 +130,7 @@ class Platform(Xilinx7SeriesPlatform):
 
     def create_programmer(self, name='openocd'):
         if name == 'openocd':
-            return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a200t.bit")
+            return OpenOCD("openocd_xc7_ft4232.cfg", "bscan_spi_xc7a200t.bit")
         elif name == 'vivado':
             # TODO: some board versions may have s25fl128s
             return VivadoProgrammer(flash_part='s25fl256sxxxxxx0-spi-x1_x2_x4')

--- a/bringup/mini/acorn_serdes/README.md
+++ b/bringup/mini/acorn_serdes/README.md
@@ -12,7 +12,7 @@
 
 [> Check
 --------
-litex_server --uart --uart-port=/dev/ttyUSBX (X=1 if only the baseboard connected).
+litex_server --uart --uart-port=/dev/ttyUSBX (X=2 if only the baseboard connected).
 ./test_prbs.py:
 Creating Serdes0
 Measuring Serdes0 frequencies...

--- a/bringup/mini/acorn_serdes/sqrl_acorn_platform.py
+++ b/bringup/mini/acorn_serdes/sqrl_acorn_platform.py
@@ -130,7 +130,7 @@ class Platform(Xilinx7SeriesPlatform):
 
     def create_programmer(self, name='openocd'):
         if name == 'openocd':
-            return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a200t.bit")
+            return OpenOCD("openocd_xc7_ft4232.cfg", "bscan_spi_xc7a200t.bit")
         elif name == 'vivado':
             # TODO: some board versions may have s25fl128s
             return VivadoProgrammer(flash_part='s25fl256sxxxxxx0-spi-x1_x2_x4')

--- a/bringup/mini/acorn_sfp_eth_1000basex/sqrl_acorn_platform.py
+++ b/bringup/mini/acorn_sfp_eth_1000basex/sqrl_acorn_platform.py
@@ -147,7 +147,7 @@ class Platform(Xilinx7SeriesPlatform):
 
     def create_programmer(self, name='openocd'):
         if name == 'openocd':
-            return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a200t.bit")
+            return OpenOCD("openocd_xc7_ft4232.cfg", "bscan_spi_xc7a200t.bit")
         elif name == 'vivado':
             # TODO: some board versions may have s25fl128s
             return VivadoProgrammer(flash_part='s25fl256sxxxxxx0-spi-x1_x2_x4')

--- a/bringup/mini/acorn_sfp_eth_2500basex/sqrl_acorn_platform.py
+++ b/bringup/mini/acorn_sfp_eth_2500basex/sqrl_acorn_platform.py
@@ -147,7 +147,7 @@ class Platform(Xilinx7SeriesPlatform):
 
     def create_programmer(self, name='openocd'):
         if name == 'openocd':
-            return OpenOCD("openocd_xc7_ft2232.cfg", "bscan_spi_xc7a200t.bit")
+            return OpenOCD("openocd_xc7_ft4232.cfg", "bscan_spi_xc7a200t.bit")
         elif name == 'vivado':
             # TODO: some board versions may have s25fl128s
             return VivadoProgrammer(flash_part='s25fl256sxxxxxx0-spi-x1_x2_x4')


### PR DESCRIPTION
The Mini variant has an FT4232 chip (VID 0403, PID 0611); default settings should reflect the hardware for better out-of-box experiences.